### PR TITLE
Fix TwoNN Off by One Error

### DIFF
--- a/skdim/id/_TwoNN.py
+++ b/skdim/id/_TwoNN.py
@@ -167,7 +167,7 @@ class TwoNN(GlobalEstimator):
                 mu = _mu[np.argsort(_mu)[: int(N * (1 - self.discard_fraction))]]
 
         # Empirical cumulate
-        Femp = np.arange(int(N * (1 - self.discard_fraction))) / N
+        Femp = np.arange(1, 1 + int(N * (1 - self.discard_fraction))) / N
 
         # Fit line
         lr = LinearRegression(fit_intercept=False)


### PR DESCRIPTION
The current implementation of the TwoNN algorithm has an off by one error when calculating the empirical CDF.

See "A Two Nearest Neighbors estimator for intrinsic dimension" -> "Step 1" in https://www.nature.com/articles/s41598-017-11873-y

The authors start at an index of 1, whereas this numpy call will start at 0.