### PR TITLE
Fix Python 3.13+ compatibility with FrameLocalsProxy

### DIFF
--- a/skdim/id/_MLE.py
+++ b/skdim/id/_MLE.py
@@ -81,7 +81,8 @@ class MLE(LocalEstimator):
         K=5,
     ):
 
-        _, _, _, values = inspect.getargvalues(inspect.currentframe())
+        _, _, _, values_proxy = inspect.getargvalues(inspect.currentframe())
+        values = dict(values_proxy)
         values.pop("self")
 
         for arg, val in values.items():


### PR DESCRIPTION
In Python 3.13+, `inspect.getargvalues()` returns a `FrameLocalsProxy` object instead of a regular dict. `FrameLocalsProxy` is read-only and cannot be modified in-place, so calling `.pop()` on it raises:

ValueError: cannot remove local variables from FrameLocalsProxy

This affects the `MLE` estimator in `skdim/id/_MLE.py` which uses this pattern to capture `__init__` arguments.

**Fix:** Convert the `FrameLocalsProxy` to a regular dict before calling `.pop()`:

```python
# Before (broken on Python 3.13+)
_, _, _, values = inspect.getargvalues(inspect.currentframe())
values.pop("self")

# After (works on all Python versions)
_, _, _, values_proxy = inspect.getargvalues(inspect.currentframe())
values = dict(values_proxy)
values.pop("self")
```

`dict(FrameLocalsProxy)` works on all Python versions, so this is a safe backwards-compatible fix.