### PR TITLE
Add center option to lPCA for uncentered participation ratio

### DIFF
--- a/skdim/id/_PCA.py
+++ b/skdim/id/_PCA.py
@@ -64,7 +64,13 @@ class lPCA(GlobalEstimator):
     PFan: float
         Only for ver = 'Fan'. Total covariance in non-noise.
     verbose: bool, default=False
-    explained_variance: bool, default=False
+    center: bool, default=True
+        If True, eigenvalues are computed from ``sklearn.decomposition.PCA``, which
+        centers (demeans) the data. If False, they are computed as the eigenvalues of
+        ``X.T @ X`` without centering, so for ver='participation_ratio' the estimate is
+        ``sum(eigenvalues) ** 2 / sum(eigenvalues ** 2)`` of ``X.T @ X``.
+        Ignored when ``fit_explained_variance`` is True.
+    fit_explained_variance: bool, default=False
         If True, lPCA.fit(X) expects as input 
         a precomputed explained_variance vector: X = sklearn.decomposition.PCA().fit(X).explained_variance_
     
@@ -84,6 +90,7 @@ class lPCA(GlobalEstimator):
         betaFan=0.8,
         PFan=0.95,
         verbose=True,
+        center=True,
         fit_explained_variance=False,
     ):
         self.ver = ver
@@ -93,6 +100,7 @@ class lPCA(GlobalEstimator):
         self.betaFan = betaFan
         self.PFan = PFan
         self.verbose = verbose
+        self.center = center
         self.fit_explained_variance = fit_explained_variance
 
     def fit(self, X, y=None):
@@ -145,9 +153,14 @@ class lPCA(GlobalEstimator):
     def _pcaLocalDimEst(self, X):
         if self.fit_explained_variance:
             explained_var = X
-        else:
+        elif self.center:
             pca = PCA().fit(X)
             self.explained_var_ = explained_var = pca.explained_variance_
+        else:
+            # Eigenvalues of X.T @ X without centering the data (issue #14).
+            # Computed from the singular values of X to avoid forming X.T @ X.
+            singular_values = np.linalg.svd(X, compute_uv=False)
+            self.explained_var_ = explained_var = singular_values ** 2
 
         if self.ver == "FO":
             return self._FO(explained_var)

--- a/skdim/tests/test_all_params.py
+++ b/skdim/tests/test_all_params.py
@@ -105,6 +105,7 @@ def test_lpca_params(data):
     x = skdim.id.lPCA(ver="Kaiser").fit(data)
     x = skdim.id.lPCA(ver="broken_stick").fit(data)
     x = skdim.id.lPCA(ver="participation_ratio").fit(data)
+    x = skdim.id.lPCA(ver="participation_ratio", center=False).fit(data)
 
 
 def test_tle_params(data):

--- a/skdim/tests/test_results.py
+++ b/skdim/tests/test_results.py
@@ -109,6 +109,42 @@ def test_lpca_results(data):
     )
 
 
+def test_lpca_center_participation_ratio():
+    # Small example with a strong non-zero mean so that centering the data
+    # (default) and not centering it give different eigenvalues (issue #14).
+    from sklearn.decomposition import PCA
+
+    X = np.array(
+        [
+            [10.0, 10.0, 0.0],
+            [10.0, 9.0, 0.0],
+            [9.0, 10.0, 1.0],
+            [11.0, 10.0, 0.0],
+            [10.0, 11.0, 0.0],
+        ]
+    )
+
+    # (a) default behavior is unchanged: participation ratio from the eigenvalues
+    # of the centered covariance matrix, i.e. sklearn PCA's explained_variance_.
+    ev_centered = PCA().fit(X).explained_variance_
+    pr_centered_expected = ev_centered.sum() ** 2 / (ev_centered ** 2).sum()
+    pr_centered = skdim.id.lPCA(ver="participation_ratio").fit(X).dimension_
+    assert np.isclose(pr_centered, pr_centered_expected)
+
+    # (b) center=False uses the eigenvalues of X.T @ X without demeaning.
+    # Independent hand computation via a symmetric eigensolver on X.T @ X.
+    eig_uncentered = np.linalg.eigvalsh(X.T @ X)
+    pr_uncentered_expected = eig_uncentered.sum() ** 2 / (eig_uncentered ** 2).sum()
+    est = skdim.id.lPCA(ver="participation_ratio", center=False).fit(X)
+    assert np.isclose(est.dimension_, pr_uncentered_expected)
+
+    # the stored eigenvalues match those of X.T @ X (up to ordering)
+    assert np.allclose(np.sort(est.explained_var_)[::-1], np.sort(eig_uncentered)[::-1])
+
+    # the two options are genuinely different on this data
+    assert not np.isclose(pr_centered, est.dimension_)
+
+
 def test_corrint_results(data):
     #     assert np.isclose(skdim.id.CorrInt().fit(data).dimension_,np.array(ider.corint(data,k1=10,k2=20)))
     assert np.isclose(skdim.id.CorrInt().fit(data).dimension_, 2.9309171335492548)


### PR DESCRIPTION
### What this adds

Closes #14. In that issue, @j-bac agreed to the request:

> "I can add an option to return eigenvalues without centering if you need it for your application, thanks for the suggestion!"

and the reporter confirmed "an optional flag would be awesome."

`lPCA` computes its eigenvalues from `sklearn.decomposition.PCA`, which centers (demeans) the data before forming the covariance. For some applications (and for `ver="participation_ratio"` in particular) the eigenvalues of the **uncentered** `X.T @ X` are wanted instead.

This adds a `center` parameter to `lPCA`:

- `center=True` (default): unchanged, eigenvalues come from `PCA().fit(X).explained_variance_`.
- `center=False`: eigenvalues are computed from `X.T @ X` without centering, via the singular values of `X` (`np.linalg.svd(X, compute_uv=False) ** 2`, which avoids forming `X.T @ X` and squaring the condition number). For `ver="participation_ratio"` this yields `sum(eigenvalues)**2 / sum(eigenvalues**2)` of `X.T @ X`, exactly as the issue requested.

The default path is unchanged (verified: `explained_var_` equals `PCA.explained_variance_`). While here I also fixed the docstring label, which read `explained_variance` for the `fit_explained_variance` parameter.

### Tests

- `test_lpca_center_participation_ratio` (new): on a small matrix with a strong non-zero mean, asserts (a) the default participation ratio still matches the PCA-eigenvalue formula, (b) the `center=False` result matches an independent `eigvalsh(X.T @ X)` computation, (c) the stored eigenvalues match those of `X.T @ X`, and (d) the two options genuinely differ.
- `test_lpca_params`: extended with a `center=False` smoke case.

Note: `test_all_estimators[lPCA]` (the sklearn `check_estimator` conformance test) fails on recent scikit-learn because the base estimator still uses `_more_tags`/`_get_tags` instead of `__sklearn_tags__`; this is pre-existing and unrelated to this change (it reproduces on `master` with these edits reverted).
